### PR TITLE
fix: add missing `env` variable to workflow

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -17,6 +17,7 @@ jobs:
       HOT_WALLET_ADDRESS: ${{ secrets.HOT_WALLET_ADDRESS }}
       HOT_WALLET_PRIVATE_KEY: ${{ secrets.HOT_WALLET_PRIVATE_KEY }}
       SPLITS_API_KEY: ${{ secrets.SPLITS_API_KEY }}
+      POPULATE_USER_ID: ${{ secrets.POPULATE_USER_ID }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/distribution.yml` file. The change adds a new secret, `POPULATE_USER_ID`, to the `jobs:` section.

* [`.github/workflows/distribution.yml`](diffhunk://#diff-15c5f0a77eb67434ea1adbcbde695d40d025b2c4436bcc45e14d9b15e642df15R20): Added `POPULATE_USER_ID` to the secrets.