### PR TITLE
feat: merge `duplicate` contributors in funding distribution calculation

### DIFF
--- a/packages/sdk/src/metrics/computeWeights.ts
+++ b/packages/sdk/src/metrics/computeWeights.ts
@@ -134,7 +134,25 @@ export const computeWeights = async (): Promise<
 
     const recipients = (await Promise.all(contributorsShares)).flat();
 
-    const fundingDistribution = recipients
+    const mergedRecipients = recipients.reduce<{
+      contributor: FundingWeight["contributor"];
+      sharePercentage: number;
+    }[]>(
+      (acc, current) => {
+        const x = acc.find(
+          (item) => item.contributor.id === current.contributor.id,
+        );
+        if (!x) {
+          return [...acc, current];
+        } else {
+          x.sharePercentage += current.sharePercentage;
+          return acc;
+        }
+      },
+      [],
+    );
+
+    const fundingDistribution = mergedRecipients
       .map(
         (contributorShare) => {
           return {
@@ -153,7 +171,7 @@ export const computeWeights = async (): Promise<
     core.startGroup("Weights");
     fundingDistribution.forEach((fundingWeight) => {
       core.info(
-        `${fundingWeight.contributor.artifact_namespace}/${fundingWeight.contributor.artifact_name}: ${fundingWeight.allocatedFunding}`,
+        `${fundingWeight.contributor.artifact_namespace}/${fundingWeight.contributor.artifact_name}: ${fundingWeight.allocatedFunding}%`,
       );
     });
     core.endGroup();


### PR DESCRIPTION
This pull request includes changes to the `packages/sdk/src/metrics/computeWeights.ts` file to improve the handling and logging of funding distribution. The most important changes include merging recipients with the same contributor ID and modifying the log message format.

Improvements to funding distribution handling:

* [`packages/sdk/src/metrics/computeWeights.ts`](diffhunk://#diff-d008aa5514be0e57cdf7ac0d40dbbc9b78ec39c005b20cb62dbddefce8643250L137-R155): Added logic to merge recipients with the same contributor ID by summing their share percentages.

Enhancements to logging:

* [`packages/sdk/src/metrics/computeWeights.ts`](diffhunk://#diff-d008aa5514be0e57cdf7ac0d40dbbc9b78ec39c005b20cb62dbddefce8643250L156-R174): Modified the log message format to include a percentage sign after the allocated funding value.